### PR TITLE
Add support for basic optional long and short options

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,11 +174,15 @@ $router->add('user list [--json] [-f]', function (array $args) {
 // matches: user list --json
 // matches: user list -f
 // matches: user list -f --json
+// matches: user -f list
+// matches: --json user list
 ```
 
 As seen in the example, options in the `$args` array can either be unset when
 they have not been passed in the user input or set to `false` when they have
 been passed (which is in line with how other parsers such as `getopt()` work).
+Note that options are accepted anywhere in the user input argument, regardless
+of where they have been defined.
 
 #### remove()
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,20 @@ $router->add('user add <name>', function (array $args) {
 // matches: user add clue
 // does not match: user add (missing required argument)
 // does not match: user add hello world (too many arguments)
+// does not match: user add --test (argument looks like an option)
+
+// matches: user add -- clue     (value: clue)
+// matches: user add -- --test   (value: --test)
+// matches: user add -- -nobody- (value: -nobody-)
+// matches: user add -- --       (value: --)
 ```
+
+Note that arguments that start with a dash (`-`) are not simply accepted in the
+user input, because they may be confused with (optional) options (see below).
+If users wish to process arguments that start with a dash (`-`), they may use
+a double dash separator (`--`), as everything after this separator will be
+processed as-is.
+See also the last examples above that demonstrate this behavior.
 
 You can mark arguments as optional by enclosing them in square brackets like this:
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,23 @@ $router->add('user dump [<names>...]', function (array $args) {
 // matches: user dump hello world
 ```
 
+You can add any number of optional short or long options like this:
+
+```php
+$router->add('user list [--json] [-f]', function (array $args) {
+    assert(!isset($args['json']) || $args['json'] === false);
+    assert(!isset($args['f']) || $args['f'] === false);
+});
+// matches: user list
+// matches: user list --json
+// matches: user list -f
+// matches: user list -f --json
+```
+
+As seen in the example, options in the `$args` array can either be unset when
+they have not been passed in the user input or set to `false` when they have
+been passed (which is in line with how other parsers such as `getopt()` work).
+
 #### remove()
 
 The `remove(Router $route)` method can be used to remove the given

--- a/src/Route.php
+++ b/src/Route.php
@@ -46,7 +46,8 @@ class Route implements TokenInterface
     {
         if ($this->token->matches($input, $output)) {
             // excessive arguments should fail, make sure input is now empty
-            if (!$input) {
+            // single remaining `--` to separate options from arguments is also accepted
+            if (!$input || (count($input) === 1 && reset($input) === '--')) {
                 return true;
             }
         }

--- a/src/Tokens/ArgumentToken.php
+++ b/src/Tokens/ArgumentToken.php
@@ -13,10 +13,12 @@ class ArgumentToken implements TokenInterface
 
     public function matches(array &$input, array &$output)
     {
-        if ($input) {
-            $value = array_shift($input);
-            $output[$this->name] = $value;
-            return true;
+        foreach ($input as $key => $value) {
+            if ($value === '' || $value[0] !== '-') {
+                unset($input[$key]);
+                $output[$this->name] = $value;
+                return true;
+            }
         }
 
         return false;

--- a/src/Tokens/ArgumentToken.php
+++ b/src/Tokens/ArgumentToken.php
@@ -13,11 +13,15 @@ class ArgumentToken implements TokenInterface
 
     public function matches(array &$input, array &$output)
     {
+        $dd = false;
         foreach ($input as $key => $value) {
-            if ($value === '' || $value[0] !== '-') {
+            if ($value === '' || $value[0] !== '-' || $dd) {
                 unset($input[$key]);
                 $output[$this->name] = $value;
                 return true;
+            } elseif ($value === '--') {
+                // found a double dash => following must be an argument
+                $dd = true;
             }
         }
 

--- a/src/Tokens/LongOptionToken.php
+++ b/src/Tokens/LongOptionToken.php
@@ -19,7 +19,8 @@ class LongOptionToken implements TokenInterface
     public function matches(array &$input, array &$output)
     {
         $pos = array_search('--' . $this->name, $input);
-        if ($pos !== false) {
+        $dd = array_search('--', $input);
+        if ($pos !== false && ($dd === false || $dd > $pos)) {
             unset($input[$pos]);
             $output[$this->name] = false;
             return true;

--- a/src/Tokens/LongOptionToken.php
+++ b/src/Tokens/LongOptionToken.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Clue\Commander\Tokens;
+
+use InvalidArgumentException;
+
+class LongOptionToken implements TokenInterface
+{
+    private $name;
+
+    public function __construct($name)
+    {
+        if (!isset($name[1])) {
+            throw new InvalidArgumentException('Long option must consist of at least two characters');
+        }
+        $this->name = $name;
+    }
+
+    public function matches(array &$input, array &$output)
+    {
+        $pos = array_search('--' . $this->name, $input);
+        if ($pos !== false) {
+            unset($input[$pos]);
+            $output[$this->name] = false;
+            return true;
+        }
+
+        return false;
+    }
+
+    public function __toString()
+    {
+        return '--' . $this->name;
+    }
+}

--- a/src/Tokens/OptionalToken.php
+++ b/src/Tokens/OptionalToken.php
@@ -13,7 +13,8 @@ class OptionalToken implements TokenInterface
 
     public function matches(array &$input, array &$output)
     {
-        if (!$input) {
+        // input is empty or has only single double dash remaining
+        if (!$input || (count($input) === 1 && reset($input) === '--')) {
             return true;
         }
 

--- a/src/Tokens/ShortOptionToken.php
+++ b/src/Tokens/ShortOptionToken.php
@@ -19,7 +19,8 @@ class ShortOptionToken implements TokenInterface
     public function matches(array &$input, array &$output)
     {
         $pos = array_search('-' . $this->name, $input);
-        if ($pos !== false) {
+        $dd = array_search('--', $input);
+        if ($pos !== false && ($dd === false || $dd > $pos)) {
             unset($input[$pos]);
             $output[$this->name] = false;
             return true;

--- a/src/Tokens/ShortOptionToken.php
+++ b/src/Tokens/ShortOptionToken.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Clue\Commander\Tokens;
+
+use InvalidArgumentException;
+
+class ShortOptionToken implements TokenInterface
+{
+    private $name;
+
+    public function __construct($name)
+    {
+        if (!isset($name[0]) || isset($name[1])) {
+            throw new InvalidArgumentException('Short option name must consist of a single character');
+        }
+        $this->name = $name;
+    }
+
+    public function matches(array &$input, array &$output)
+    {
+        $pos = array_search('-' . $this->name, $input);
+        if ($pos !== false) {
+            unset($input[$pos]);
+            $output[$this->name] = false;
+            return true;
+        }
+
+        return false;
+    }
+
+    public function __toString()
+    {
+        return '-' . $this->name;
+    }
+}

--- a/src/Tokens/Tokenizer.php
+++ b/src/Tokens/Tokenizer.php
@@ -79,12 +79,15 @@ class Tokenizer
                     $ellipse = true;
                 }
 
-                // for now, the optional block may only contain arguments
-                if (substr($word, 0, 1) !== '<' || substr($word, -1) !== '>') {
-                    throw new InvalidArgumentException('Optional block must contain argument block');
+                if (substr($word, 0, 2) === '--') {
+                    $token = new LongOptionToken(substr($word, 2));
+                } elseif (substr($word, 0, 1) === '-') {
+                    $token = new ShortOptionToken(substr($word, 1));
+                } elseif (substr($word, 0, 1) === '<' && substr($word, -1) === '>') {
+                    $token = new ArgumentToken(substr($word, 1, -1));
+                } else{
+                    throw new InvalidArgumentException('Optional block must contain option or argument block');
                 }
-
-                $token = new ArgumentToken(substr($word, 1, -1));
 
                 if ($ellipse) {
                     $token = new EllipseToken($token);

--- a/src/Tokens/WordToken.php
+++ b/src/Tokens/WordToken.php
@@ -13,9 +13,14 @@ class WordToken implements TokenInterface
 
     public function matches(array &$input, array &$output)
     {
-        if (isset($input[0]) && $input[0] === $this->word) {
-            array_shift($input);
-            return true;
+        foreach ($input as $key => $value) {
+            if ($value === $this->word) {
+                unset($input[$key]);
+                return true;
+            } elseif ($value === '' || $value[0] !== '-') {
+                // any other word/argument (non-option) found => fail
+                break;
+            }
         }
         return false;
     }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -204,6 +204,70 @@ class RouterTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $invoked);
     }
 
+    public function testHandleAddedRouteWithOptionalLongOption()
+    {
+        $router = new Router();
+
+        $invoked = null;
+        $router->add('hello [--test]', function ($args) use (&$invoked) {
+            $invoked = $args;
+        });
+
+        $this->assertNull($invoked);
+
+        $router->handleArgs(array('hello', '--test'));
+
+        $this->assertEquals(array('test' => false), $invoked);
+    }
+
+    public function testHandleAddedRouteWithoutOptionalLongOption()
+    {
+        $router = new Router();
+
+        $invoked = null;
+        $router->add('hello [--test]', function ($args) use (&$invoked) {
+            $invoked = $args;
+        });
+
+        $this->assertNull($invoked);
+
+        $router->handleArgs(array('hello'));
+
+        $this->assertEquals(array(), $invoked);
+    }
+
+    public function testHandleAddedRouteWithOptionalShortOption()
+    {
+        $router = new Router();
+
+        $invoked = null;
+        $router->add('hello [-i]', function ($args) use (&$invoked) {
+            $invoked = $args;
+        });
+
+        $this->assertNull($invoked);
+
+        $router->handleArgs(array('hello', '-i'));
+
+        $this->assertEquals(array('i' => false), $invoked);
+    }
+
+    public function testHandleAddedRouteWithoutOptionalShortOption()
+    {
+        $router = new Router();
+
+        $invoked = null;
+        $router->add('hello [-i]', function ($args) use (&$invoked) {
+            $invoked = $args;
+        });
+
+        $this->assertNull($invoked);
+
+        $router->handleArgs(array('hello'));
+
+        $this->assertEquals(array(), $invoked);
+    }
+
     /**
      * @expectedException Clue\Commander\NoRouteFoundException
      */
@@ -223,6 +287,17 @@ class RouterTest extends PHPUnit_Framework_TestCase
         $router->add('hello', 'var_dump');
 
         $router->handleArgs(array('test'));
+    }
+
+    /**
+     * @expectedException Clue\Commander\NoRouteFoundException
+     */
+    public function testHandleRouteWithExcessiveArgumentsDoesNotMatch()
+    {
+        $router = new Router();
+        $router->add('hello', 'var_dump');
+
+        $router->handleArgs(array('hello', 'world'));
     }
 
     /**
@@ -256,5 +331,27 @@ class RouterTest extends PHPUnit_Framework_TestCase
         $router->add('hello <names>...', 'var_dump');
 
         $router->handleArgs(array('hello'));
+    }
+
+    /**
+     * @expectedException Clue\Commander\NoRouteFoundException
+     */
+    public function testHandleRouteWithoutLongOptionDoesNotMatch()
+    {
+        $router = new Router();
+        $router->add('hello [--test]', 'var_dump');
+
+        $router->handleArgs(array('hello', 'test'));
+    }
+
+    /**
+     * @expectedException Clue\Commander\NoRouteFoundException
+     */
+    public function testHandleRouteWithoutShortOptionDoesNotMatch()
+    {
+        $router = new Router();
+        $router->add('hello [-i]', 'var_dump');
+
+        $router->handleArgs(array('hello', 'test'));
     }
 }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -284,6 +284,54 @@ class RouterTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array('test' => false, 'i' => false), $invoked);
     }
 
+    public function testHandleAddedRouteWithArgumentIgnoresDoubleDash()
+    {
+        $router = new Router();
+
+        $invoked = null;
+        $router->add('hello <name>', function ($args) use (&$invoked) {
+            $invoked = $args;
+        });
+
+        $this->assertNull($invoked);
+
+        $router->handleArgs(array('hello', '--', 'clue'));
+
+        $this->assertEquals(array('name' => 'clue'), $invoked);
+    }
+
+    public function testHandleAddedRouteWithArgumentStartingWithDash()
+    {
+        $router = new Router();
+
+        $invoked = null;
+        $router->add('hello <name>', function ($args) use (&$invoked) {
+            $invoked = $args;
+        });
+
+        $this->assertNull($invoked);
+
+        $router->handleArgs(array('hello', '--', '-nobody-'));
+
+        $this->assertEquals(array('name' => '-nobody-'), $invoked);
+    }
+
+    public function testHandleAddedRouteWithoutOptionalArgumentIgnoresDoubleDash()
+    {
+        $router = new Router();
+
+        $invoked = null;
+        $router->add('hello [<name>]', function ($args) use (&$invoked) {
+            $invoked = $args;
+        });
+
+        $this->assertNull($invoked);
+
+        $router->handleArgs(array('hello', '--'));
+
+        $this->assertEquals(array(), $invoked);
+    }
+
     /**
      * @expectedException Clue\Commander\NoRouteFoundException
      */
@@ -380,6 +428,17 @@ class RouterTest extends PHPUnit_Framework_TestCase
         $router->add('hello <name>', 'var_dump');
 
         $router->handleArgs(array('hello', '--test'));
+    }
+
+    /**
+     * @expectedException Clue\Commander\NoRouteFoundException
+     */
+    public function testHandleRouteWithExplicitDashArgumentInsteadOfOptionDoesNotMatch()
+    {
+        $router = new Router();
+        $router->add('hello [--test]', 'var_dump');
+
+        $router->handleArgs(array('hello', '--', '--test'));
     }
 
     /**

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -268,6 +268,22 @@ class RouterTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $invoked);
     }
 
+    public function testHandleAddedRouteWithOptionalLongAndShortOptionBeforeWords()
+    {
+        $router = new Router();
+
+        $invoked = null;
+        $router->add('hello [--test] [-i]', function ($args) use (&$invoked) {
+            $invoked = $args;
+        });
+
+        $this->assertNull($invoked);
+
+        $router->handleArgs(array('-i', '--test', 'hello'));
+
+        $this->assertEquals(array('test' => false, 'i' => false), $invoked);
+    }
+
     /**
      * @expectedException Clue\Commander\NoRouteFoundException
      */
@@ -353,5 +369,27 @@ class RouterTest extends PHPUnit_Framework_TestCase
         $router->add('hello [-i]', 'var_dump');
 
         $router->handleArgs(array('hello', 'test'));
+    }
+
+    /**
+     * @expectedException Clue\Commander\NoRouteFoundException
+     */
+    public function testHandleRouteWithOptionInsteadOfArgumentDoesNotMatch()
+    {
+        $router = new Router();
+        $router->add('hello <name>', 'var_dump');
+
+        $router->handleArgs(array('hello', '--test'));
+    }
+
+    /**
+     * @expectedException Clue\Commander\NoRouteFoundException
+     */
+    public function testHandleRouteWordDoesNotMatch()
+    {
+        $router = new Router();
+        $router->add('hello word [<any>]', 'var_dump');
+
+        $router->handleArgs(array('hello', 'not', 'word'));
     }
 }

--- a/tests/Tokens/TokenizerTest.php
+++ b/tests/Tokens/TokenizerTest.php
@@ -57,6 +57,20 @@ class TokenizerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('hello [<name>]', $tokens);
     }
 
+    public function testWordWithOptionalLongOption()
+    {
+        $tokens = $this->tokenizer->createToken("hello [--upper]");
+
+        $this->assertEquals('hello [--upper]', $tokens);
+    }
+
+    public function testWordWithOptionalShortOption()
+    {
+        $tokens = $this->tokenizer->createToken("hello [-f]");
+
+        $this->assertEquals('hello [-f]', $tokens);
+    }
+
     public function testWordWithArgumentEllipses()
     {
         $tokens = $this->tokenizer->createToken("hello <name>...");
@@ -85,5 +99,21 @@ class TokenizerTest extends PHPUnit_Framework_TestCase
     public function testOptionalBlockMustContainArgument()
     {
         $this->tokenizer->createToken("hello [world]");
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testOptionalLongOptionMustContainAtLeastTwoChars()
+    {
+        $this->tokenizer->createToken("hello [--s]");
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testOptionalShortOptionMustOnlyBeSingleCharacter()
+    {
+        $this->tokenizer->createToken("hello [-nope]");
     }
 }


### PR DESCRIPTION
Closes #2 

This is a BC break because we no longer accept keyword that start with a dash (`-`). Added support for double dash separator (`--`) in input to mark following as argument.