### PR TITLE
Be explicit about left-associative grammer (LAG)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,17 @@ to route incoming HTTP requests to the corresponding "controller functions":
 $route = $router->add($path, $fn);
 ```
 
-The route expression aims to be so simple that both consumers of this library
+The route expression uses a custom domain-specific language (DSL) which aims to
+be so simple that both consumers of this library
 (i.e. developers) and users of your resulting tools should be able to understand
 them.
+
+Note that this is a left-associative grammar (LAG) and all tokens are greedy.
+This means that the tokens will be processed from left to right and each token
+will try to match as many of the input arguments as possible.
+This implies that certain route expressions make little sense, such as having
+an optional argument after an argument with ellipses.
+For more details, see below.
 
 You can use an empty string like this to match when no arguments have been given:
 
@@ -149,6 +157,11 @@ $router->add('user search [<query>]', function (array $args) {
 Note that square brackets can be added to pretty much any token in your route
 expression, however they are most commonly used for arguments as above or for
 optional options as below.
+Optional tokens can appear anywhere in the route expression, but keep in mind
+that the tokens will be matched from left to right, so if the optional token
+matches, then the remainder will be processed by the following tokens.
+As a rule of thumb, make sure optional tokens are near the end of your route
+expressions and you won't notice this subtle effect.
 
 You can accept any number of arguments by appending ellipses like this:
 
@@ -167,6 +180,12 @@ Note that trailing ellipses can be added to pretty much any token in your route
 expression, however they are most commonly used for arguments as above.
 The above requires at least one argument, see the following if you want this
 to be completely optional.
+Technically, the ellipse tokens can appear anywhere in the route expression, but
+keep in mind that the tokens will be matched from the left to the right, so if
+the ellipse matches, it will consume all input arguments and not leave anything
+for following tokens.
+As a rule of thumb, make sure ellipse tokens are near the end of your route
+expression and you won't notice this subtle effect.
 
 You can accept any number of optional arguments by appending ellipses within square brackets like this:
 

--- a/src/Tokens/OptionalToken.php
+++ b/src/Tokens/OptionalToken.php
@@ -19,12 +19,8 @@ class OptionalToken implements TokenInterface
 
     public function matches(array &$input, array &$output)
     {
-        // input is empty or has only single double dash remaining
-        if (!$input || (count($input) === 1 && reset($input) === '--')) {
-            return true;
-        }
-
-        return $this->token->matches($input, $output);
+        // try greedy match for sub-token or succeed anyway
+        return $this->token->matches($input, $output) || true;
     }
 
     public function __toString()

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -252,6 +252,38 @@ class RouterTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $invoked);
     }
 
+    public function testHandleAddedRouteWithoutOptionalLongOptionFirst()
+    {
+        $router = new Router();
+
+        $invoked = null;
+        $router->add('[--test] hello', function ($args) use (&$invoked) {
+            $invoked = $args;
+        });
+
+        $this->assertNull($invoked);
+
+        $router->handleArgs(array('hello'));
+
+        $this->assertEquals(array(), $invoked);
+    }
+
+    public function testHandleAddedRouteWithOptionalLongOptionFirst()
+    {
+        $router = new Router();
+
+        $invoked = null;
+        $router->add('[--test] hello', function ($args) use (&$invoked) {
+            $invoked = $args;
+        });
+
+        $this->assertNull($invoked);
+
+        $router->handleArgs(array('hello', '--test'));
+
+        $this->assertEquals(array('test' => false), $invoked);
+    }
+
     public function testHandleAddedRouteWithOptionalShortOption()
     {
         $router = new Router();
@@ -411,6 +443,28 @@ class RouterTest extends PHPUnit_Framework_TestCase
         $router->add('hello <names>...', 'var_dump');
 
         $router->handleArgs(array('hello'));
+    }
+
+    /**
+     * @expectedException Clue\Commander\NoRouteFoundException
+     */
+    public function testHandleAddedRouteWithKeywordAfterEllipseArgumentsDoesNotMatch()
+    {
+        $router = new Router();
+        $router->add('hello <names>... test', 'var_dump');
+
+        $router->handleArgs(array('hello', 'a', 'b', 'test'));
+    }
+
+    /**
+     * @expectedException Clue\Commander\NoRouteFoundException
+     */
+    public function testHandleAddedRouteWithoutKeywordAfterOptionalKeywordDoesNotMatch()
+    {
+        $router = new Router();
+        $router->add('hello [user] user', 'var_dump');
+
+        $router->handleArgs(array('hello', 'user'));
     }
 
     /**


### PR DESCRIPTION
Be explicit about this using a LAG, something subtle you only notice in rare cases.

Builds on top of #9.