### PR TITLE
Support preset option values

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ Note that alternative blocks can be added to pretty much any token in your route
 expression.
 Note that alternative blocks do not require parentheses and the alternative mark
 (`|`) always works at the current block level, which may not always be obvious.
-Unless you add some parenthesis, `a b | c d` will be be interpreted as
+Unless you add some parentheses, `a b | c d` will be be interpreted as
 `(a b) | (c d)` by default.
-Parenthesis can be used to interpret this as `a (b | c) d` instead.
+Parentheses can be used to interpret this as `a (b | c) d` instead.
 In particular, you can also combine alternative blocks with optional blocks
 (see below) in order to optionally accept only one of the alternatives, but not
 multiple.
@@ -308,6 +308,38 @@ Note that it is highly recommended to always make sure any options that accept
 values are near the left side of your route expression.
 This is needed in order to make sure space-separated values are consumed as
 option values instead of being misinterpreted as keywords or arguments.
+
+You can limit the values for short and long options to a given preset like this:
+
+```php
+$router->add('[--ask=(yes|no)] [-l[=0]] user purge', function (array $args) {
+    assert(!isset($args['ask']) || $args['sort'] === 'yes' || $args['sort'] === 'no');
+    assert(!isset($args['l']) || $args['l'] === '0');
+});
+// matches: user purge
+// matches: user purge --ask=yes
+// matches: user purge --ask=no
+// matches: user purge -l
+// matches: user purge -l=0
+// matches: user purge -l 0
+// matches: user purge -l0
+// matches: user purge -l --ask=no
+// does not match: user purge --ask (missing option value)
+// does not match: user purge --ask=maybe (invalid option value)
+// does not match: user purge -l4 (invalid option value)
+```
+
+As seen in the example, option values can be restricted to a given preset of
+values by using any of the above tokens.
+Technically, it's valid to use any of the above tokens to restrict the option
+values.
+In practice, this is mostly used for static keyword tokens or alternative groups
+thereof.
+It's recommended to always use parentheses for optional groups, however they're
+not strictly required within options with optional values.
+This also helps making it more obvious `[--ask=(yes|no)]` would accept either
+option value, while the (less useful) expression `[--ask=yes | no]` would
+accept either the option `--ask=yes` or the static keyword `no`.
 
 #### remove()
 

--- a/src/Tokens/ArgumentToken.php
+++ b/src/Tokens/ArgumentToken.php
@@ -2,12 +2,17 @@
 
 namespace Clue\Commander\Tokens;
 
+use InvalidArgumentException;
+
 class ArgumentToken implements TokenInterface
 {
     private $name;
 
     public function __construct($name)
     {
+        if (!isset($name[0])) {
+            throw new InvalidArgumentException('Empty argument name');
+        }
         $this->name = $name;
     }
 

--- a/src/Tokens/OptionToken.php
+++ b/src/Tokens/OptionToken.php
@@ -10,7 +10,7 @@ class OptionToken implements TokenInterface
     private $placeholder;
     private $required;
 
-    public function __construct($name, $placeholder = null, $required = false)
+    public function __construct($name, TokenInterface $placeholder = null, $required = false)
     {
         if (!isset($name[1]) || $name[0] !== '-') {
             throw new InvalidArgumentException('Option name must start with a dash');
@@ -22,11 +22,12 @@ class OptionToken implements TokenInterface
             throw new InvalidArgumentException('Long option must consist of at least two characters');
         }
 
-        if ($placeholder !== null && !isset($placeholder[0])) {
-            throw new InvalidArgumentException('Option placeholder must not be empty');
+        if ($placeholder !== null && !$placeholder instanceof ArgumentToken) {
+            throw new InvalidArgumentException('Option placeholder must be unset or an argument');
         }
+
         if ($required && $placeholder === null) {
-            throw new InvalidArgumentException('Requires placeholder name when option value is required');
+            throw new InvalidArgumentException('Requires a placeholder when option value is marked required');
         }
 
         $this->name = $name;
@@ -114,7 +115,7 @@ class OptionToken implements TokenInterface
             if (!$this->required) {
                 $ret .= '[';
             }
-            $ret .= '=<' . $this->placeholder . '>';
+            $ret .= '=' . $this->placeholder;
             if (!$this->required) {
                 $ret .= ']';
             }

--- a/src/Tokens/Tokenizer.php
+++ b/src/Tokens/Tokenizer.php
@@ -196,11 +196,12 @@ class Tokenizer
         $i += strlen($word);
 
         if (isset($word[0]) && $word[0] === '-') {
-            if (isset($input[$i + 2]) && $input[$i] === '[' && $input[$i + 1] === '=' && $input[$i + 2] === '<') {
+            if (isset($input[$i + 1]) && $input[$i] === '[' && $input[$i + 1] === '=') {
                 // placeholder value is optional
-                // skip opening `[=`, read argument and expect closing bracket
+                // skip opening `[=`, read placeholder token and expect closing bracket
+                // placeholder may contain alternatives because the surrounded brackets make this unambiguous
                 $i += 2;
-                $placeholder = $this->readArgument($input, $i);
+                $placeholder = $this->readAlternativeSentenceOrSingle($input, $i);
 
                 if (!isset($input[$i]) || $input[$i] !== ']') {
                     throw new InvalidArgumentException('Missing end of optional option value');
@@ -209,11 +210,12 @@ class Tokenizer
                 // skip trailing closing bracket
                 $i++;
                 $required = false;
-            } elseif (isset($input[$i + 1]) && $input[$i] === '=' && $input[$i + 1] === '<') {
+            } elseif (isset($input[$i + 1]) && $input[$i] === '=') {
                 // placeholder value is required
                 // skip one character for `=` and read until end of <argument>
+                // placeholder may only contain single token because it's terminated at ambiguous whitespace
                 $i++;
-                $placeholder = $this->readArgument($input, $i);
+                $placeholder = $this->readToken($input, $i);
                 $required = true;
             } else {
                 $required = false;

--- a/src/Tokens/Tokenizer.php
+++ b/src/Tokens/Tokenizer.php
@@ -75,7 +75,7 @@ class Tokenizer
         for (;isset($input[$i]) && in_array($input[$i], $this->ws); ++$i);
     }
 
-    private function readToken($input, &$i)
+    private function readToken($input, &$i, $readEllipses = true)
     {
         if ($input[$i] === '<') {
             $token = $this->readArgument($input, $i);
@@ -92,7 +92,7 @@ class Tokenizer
         $this->consumeOptionalWhitespace($input, $start);
 
         // found `...` after some optional whitespace
-        if (substr($input, $start, 3) === '...') {
+        if ($readEllipses && substr($input, $start, 3) === '...') {
             $token = new EllipseToken($token);
             $i = $start + 3;
         }
@@ -234,7 +234,9 @@ class Tokenizer
                 $this->consumeOptionalWhitespace($input, $i);
 
                 // placeholder may only contain single token because it's terminated at ambiguous whitespace
-                $placeholder = $this->readToken($input, $i);
+                // we explicitly skip consuming the ellipses as part of the option value here
+                // trailing ellipses should be part of the whole option, not only its value
+                $placeholder = $this->readToken($input, $i, false);
                 $required = true;
             } else {
                 // ignore unknown character at cursor position because it is not part of this option value

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -181,6 +181,11 @@ class RouterTest extends PHPUnit_Framework_TestCase
                 array('hello', '--name', 'b'),
                 array('name' => 'b'),
             ),
+            'word with required long option with required keyword ellipses' => array(
+                'hello --ask=no...',
+                array('hello', '--ask=no', '--ask=no'),
+                array('ask' => array('no', 'no')),
+            ),
 
             'word with required short option with required value' => array(
                 'hello -i=<n>',

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -171,6 +171,16 @@ class RouterTest extends PHPUnit_Framework_TestCase
                 array('hello', '--name', '--yes'),
                 array('name' => false, 'yes' => false),
             ),
+            'word with required long option with required alternative value' => array(
+                'hello --name=(a | b)',
+                array('hello', '--name=a'),
+                array('name' => 'a'),
+            ),
+            'word with required long option with required alternative value separated' => array(
+                'hello --name=(a | b)',
+                array('hello', '--name', 'b'),
+                array('name' => 'b'),
+            ),
 
             'word with required short option with required value' => array(
                 'hello -i=<n>',
@@ -327,6 +337,14 @@ class RouterTest extends PHPUnit_Framework_TestCase
             'alternative options do not accept both' => array(
                 'test [--help | -h]',
                 array('test', '--help', '-h')
+            ),
+            'with required long option with value not in alternative group' => array(
+                'hello --name=(a | b)',
+                array('hello', '--name=c'),
+            ),
+            'with required long option with value separated not in alternative group' => array(
+                'hello --name=(a | b)',
+                array('hello', '--name', 'c'),
             ),
         );
     }

--- a/tests/Tokens/OptionTokenTest.php
+++ b/tests/Tokens/OptionTokenTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Clue\Commander\Tokens\OptionToken;
+use Clue\Commander\Tokens\WordToken;
 
 class OptionTokenTest extends PHPUnit_Framework_TestCase
 {
@@ -10,5 +11,13 @@ class OptionTokenTest extends PHPUnit_Framework_TestCase
     public function testUnableToCreateOptionWithRequiredValueButNoPlaceholder()
     {
         new OptionToken('--name', null, true);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testUnableToCreateOptionWithWordPlaceholderToken()
+    {
+        new OptionToken('--name', new WordToken('test'));
     }
 }

--- a/tests/Tokens/OptionTokenTest.php
+++ b/tests/Tokens/OptionTokenTest.php
@@ -12,12 +12,4 @@ class OptionTokenTest extends PHPUnit_Framework_TestCase
     {
         new OptionToken('--name', null, true);
     }
-
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function testUnableToCreateOptionWithWordPlaceholderToken()
-    {
-        new OptionToken('--name', new WordToken('test'));
-    }
 }

--- a/tests/Tokens/TokenizerTest.php
+++ b/tests/Tokens/TokenizerTest.php
@@ -116,7 +116,10 @@ class TokenizerTest extends PHPUnit_Framework_TestCase
                 '<first>[word]'
             ),
 
-            'incomplete parameter block' => array(
+            'empty argument block' => array(
+                '<>'
+            ),
+            'incomplete argument block' => array(
                 '<incomplete'
             ),
             'incomplete optional argument' => array(
@@ -150,6 +153,12 @@ class TokenizerTest extends PHPUnit_Framework_TestCase
             ),
             'long option with empty placeholder name' => array(
                 '--date=<>'
+            ),
+            'option with incomplete placeholder' => array(
+                '--date=<a'
+            ),
+            'option with incomplete optional placeholder' => array(
+                '--date[=<a>'
             ),
 
             'empty sentence in alternative block' => array(

--- a/tests/Tokens/TokenizerTest.php
+++ b/tests/Tokens/TokenizerTest.php
@@ -41,7 +41,7 @@ class TokenizerTest extends PHPUnit_Framework_TestCase
             'word with required long option' => array(
                 'hello --upper'
             ),
-            'word with optional short option' => array(
+            'word with required short option' => array(
                 'hello -f'
             ),
             'word with optional long option' => array(
@@ -61,6 +61,33 @@ class TokenizerTest extends PHPUnit_Framework_TestCase
             ),
             'word with required short option with optional value' => array(
                 'hello -f[=<date>]'
+            ),
+            'word with required long option with required word' => array(
+                'hello --date=now'
+            ),
+//             'word with required long option with required word ellipses' => array(
+//                 'hello --date=now...'
+//             ),
+            'word with required long option with required sentence nonsense' => array(
+                'hello --date=(hello world)'
+            ),
+            'word with required long option with optional word' => array(
+                'hello --date[=now]'
+            ),
+            'word with required long option with optional word ellipses' => array(
+                'hello --date[=now]...'
+            ),
+            'word with required long option with optional sentence does not require parentheses nonsense' => array(
+                'hello --date[=hello world]'
+            ),
+            'word with required long option with optional word ellipses does not require parentheses nonsense' => array(
+                'hello --date[=now...]'
+            ),
+            'word with required long option with required group does require parentheses' => array(
+                'hello --date=(a | b)'
+            ),
+            'word with required long option with optional group do not require parentheses' => array(
+                'hello --date[=a | b]'
             ),
 
             'word with ellipse arguments' => array(
@@ -281,5 +308,48 @@ class TokenizerTest extends PHPUnit_Framework_TestCase
         $tokens = $this->tokenizer->createToken('a | (b | c) | d');
 
         $this->assertEquals('a | b | c | d', $tokens);
+    }
+
+    public function testOptionWithRequiredWordEllipses()
+    {
+        $this->markTestIncomplete();
+
+        $tokens = $this->tokenizer->createToken('hello --date=now...');
+
+        $this->assertEquals('hello --date=now...', $tokens);
+    }
+
+    public function testOptionWithRequiredWordEllipsesWithOptionalParentheses()
+    {
+        $this->markTestIncomplete();
+
+        $tokens = $this->tokenizer->createToken('hello (--date=(now))...');
+
+        $this->assertEquals('hello --date=now...', $tokens);
+    }
+
+    public function testOptionWithRequiredWordValueWithWhitespace()
+    {
+        $this->markTestIncomplete();
+
+        $tokens = $this->tokenizer->createToken('--option  = value ');
+
+        $this->assertEquals('--option=value', $tokens);
+    }
+
+    public function testOptionWithOptionalWordValueWithWhitespace()
+    {
+        $this->markTestIncomplete();
+
+        $tokens = $this->tokenizer->createToken('--option [ = value ]');
+
+        $this->assertEquals('--option[=value]', $tokens);
+    }
+
+    public function testParenthesesForSentenceInOptionalOptionValueIsOptional()
+    {
+        $tokens = $this->tokenizer->createToken('--option[=(hello world)]');
+
+        $this->assertEquals('--option[=hello world]', $tokens);
     }
 }

--- a/tests/Tokens/TokenizerTest.php
+++ b/tests/Tokens/TokenizerTest.php
@@ -50,6 +50,9 @@ class TokenizerTest extends PHPUnit_Framework_TestCase
             'word with optional short option' => array(
                 'hello [-f]'
             ),
+            'word with required short option and optional short option' => array(
+                'hello -i [-f]'
+            ),
             'word with required long option with required value' => array(
                 'hello --date=<when>'
             ),
@@ -330,18 +333,14 @@ class TokenizerTest extends PHPUnit_Framework_TestCase
 
     public function testOptionWithRequiredWordValueWithWhitespace()
     {
-        $this->markTestIncomplete();
-
-        $tokens = $this->tokenizer->createToken('--option  = value ');
+        $tokens = $this->tokenizer->createToken('--option = value ');
 
         $this->assertEquals('--option=value', $tokens);
     }
 
     public function testOptionWithOptionalWordValueWithWhitespace()
     {
-        $this->markTestIncomplete();
-
-        $tokens = $this->tokenizer->createToken('--option [ = value ]');
+        $tokens = $this->tokenizer->createToken('--option [ = value ] ');
 
         $this->assertEquals('--option[=value]', $tokens);
     }

--- a/tests/Tokens/TokenizerTest.php
+++ b/tests/Tokens/TokenizerTest.php
@@ -68,9 +68,9 @@ class TokenizerTest extends PHPUnit_Framework_TestCase
             'word with required long option with required word' => array(
                 'hello --date=now'
             ),
-//             'word with required long option with required word ellipses' => array(
-//                 'hello --date=now...'
-//             ),
+            'word with required long option with required word ellipses' => array(
+                'hello --date=now...'
+            ),
             'word with required long option with required sentence nonsense' => array(
                 'hello --date=(hello world)'
             ),
@@ -315,15 +315,6 @@ class TokenizerTest extends PHPUnit_Framework_TestCase
         $tokens = $this->tokenizer->createToken('a | (b | c) | d');
 
         $this->assertEquals('a | b | c | d', $tokens);
-    }
-
-    public function testOptionWithRequiredWordEllipses()
-    {
-        $this->markTestIncomplete();
-
-        $tokens = $this->tokenizer->createToken('hello --date=now...');
-
-        $this->assertEquals('hello --date=now...', $tokens);
     }
 
     public function testOptionWithRequiredWordEllipsesWithOptionalParentheses()

--- a/tests/Tokens/TokenizerTest.php
+++ b/tests/Tokens/TokenizerTest.php
@@ -219,9 +219,6 @@ class TokenizerTest extends PHPUnit_Framework_TestCase
             'ellipse after alternative group' => array(
                 '(a | b)...'
             ),
-            'ellipse after word in parentheses' => array(
-                '(a)...'
-            ),
         );
     }
 
@@ -292,6 +289,13 @@ class TokenizerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('hello', $tokens);
     }
 
+    public function testParenthesesForWordWithParenthesesIsOptional()
+    {
+        $tokens = $this->tokenizer->createToken('(((hello))...)');
+
+        $this->assertEquals('hello...', $tokens);
+    }
+
     public function testParenthesesAroundWordInSentenceIsOptional()
     {
         $tokens = $this->tokenizer->createToken('a (b) c');
@@ -324,8 +328,6 @@ class TokenizerTest extends PHPUnit_Framework_TestCase
 
     public function testOptionWithRequiredWordEllipsesWithOptionalParentheses()
     {
-        $this->markTestIncomplete();
-
         $tokens = $this->tokenizer->createToken('hello (--date=(now))...');
 
         $this->assertEquals('hello --date=now...', $tokens);


### PR DESCRIPTION
Option values now accept any kind of token, which means they no longer simply accept any value. It is now possible to pass an alternative group to limit this to a preset of valid option values.

The tokenizer/parser has been updated to properly recurse into option values and now accepts whitespace and optional parentheses as expected.

The tokenizer/parser has also been updated to use an argument token if you still want to accept any value. This means we now share quite a bit of code between these, which is also a necessary preparation for #13.

Closes #6.