### PR TITLE
Fix: Use casted filter value for options with boolean values

### DIFF
--- a/src/Tokens/OptionToken.php
+++ b/src/Tokens/OptionToken.php
@@ -141,7 +141,7 @@ class OptionToken implements TokenInterface
 
                 // if the value parsed as an option, its value will be `false`
                 // rather keep name in that case, otherwise use parsed value
-                if ($temp !== false) {
+                if ($temp !== false || $value === '' || $value[0] !== '-') {
                     $value = $temp;
                 }
             }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -206,6 +206,16 @@ class RouterTest extends PHPUnit_Framework_TestCase
                 array('hello', '--name', '-10'),
                 array('name' => -10)
             ),
+            'word with required long option with required filtered bool value' => array(
+                'hello --force=<n:bool>',
+                array('hello', '--force=no'),
+                array('force' => false)
+            ),
+            'word with required long option with required filtered bool value separated' => array(
+                'hello --force=<n:bool>',
+                array('hello', '--force', 'false'),
+                array('force' => false)
+            ),
             'word with required long option with required alternative value' => array(
                 'hello --name=(a | b)',
                 array('hello', '--name=a'),

--- a/tests/Tokens/TokenizerTest.php
+++ b/tests/Tokens/TokenizerTest.php
@@ -193,13 +193,16 @@ class TokenizerTest extends PHPUnit_Framework_TestCase
             'option name is missing' => array(
                 '-'
             ),
+            'long option with no value' => array(
+                '--date=<>'
+            ),
             'long option with empty placeholder name' => array(
                 '--date=<>'
             ),
-            'option with incomplete placeholder' => array(
+            'long option with incomplete placeholder' => array(
                 '--date=<a'
             ),
-            'option with incomplete optional placeholder' => array(
+            'long option with incomplete optional placeholder' => array(
                 '--date[=<a>'
             ),
 


### PR DESCRIPTION
Matching the expression `hello --force=<n:bool>` with the user input `hello --force=false` will now return the correct `(bool)false` value intead of `(string)"false"`.