### PR TITLE
Add support for custom filter callbacks

### DIFF
--- a/src/Tokens/ArgumentToken.php
+++ b/src/Tokens/ArgumentToken.php
@@ -8,17 +8,25 @@ class ArgumentToken implements TokenInterface
 {
     private $name;
     private $filter;
+    private $callback;
 
-    public function __construct($name, $filter = null)
+    public function __construct($name, $filter = null, $callback = null)
     {
         if (!isset($name[0])) {
             throw new InvalidArgumentException('Empty argument name');
         }
+        if (($filter === null && $callback !== null) || ($callback !== null && !is_callable($callback))) {
+            throw new InvalidArgumentException('Invalid callback given or no filter name for callback given');
+        }
         $this->name = $name;
         $this->filter = $filter;
+        $this->callback = $callback;
 
-        $demo = '';
-        $this->validate($demo, false);
+        // validate filter name by simply invoking once
+        if ($callback === null) {
+            $demo = '';
+            $this->validate($demo, false);
+        }
     }
 
     public function matches(array &$input, array &$output)
@@ -57,6 +65,14 @@ class ArgumentToken implements TokenInterface
         if ($this->filter === null) {
             // value must not start with a dash (`-`), unless it's behind a double dash (`--`)
             return ($dd || $value === '' || $value[0] !== '-');
+        } elseif ($this->callback !== null) {
+            $callback = $this->callback;
+            $ret = $value;
+            if (!$callback($ret)) {
+                return false;
+            }
+            $value = $ret;
+            return true;
         } elseif ($this->filter === 'int' || $this->filter === 'uint') {
             $ret = filter_var($value, FILTER_VALIDATE_INT);
             if ($ret === false || ($this->filter === 'uint' && $ret < 0)) {

--- a/src/Tokens/Tokenizer.php
+++ b/src/Tokens/Tokenizer.php
@@ -21,6 +21,18 @@ class Tokenizer
         "\n",
     );
 
+    private $filters = array();
+
+    /**
+     * @param string $name
+     * @param callback $filter
+     * @return void
+     */
+    public function addFilter($name, $filter)
+    {
+        $this->filters[$name] = $filter;
+    }
+
     /**
      * Creates a Token from the given route expression
      *
@@ -117,8 +129,13 @@ class Tokenizer
         $parts = explode(':', $word, 2);
         $word = trim($parts[0]);
         $filter = isset($parts[1]) ? trim($parts[1]) : null;
+        $callback =  null;
 
-        return new ArgumentToken($word, $filter);
+        if ($filter !== null && isset($this->filters[$filter])) {
+            $callback = $this->filters[$filter];
+        }
+
+        return new ArgumentToken($word, $filter, $callback);
     }
 
     private function readOptionalBlock($input, &$i)

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Clue\Commander\Router;
+use Clue\Commander\Tokens\Tokenizer;
 
 class RouterTest extends PHPUnit_Framework_TestCase
 {
@@ -452,6 +453,25 @@ class RouterTest extends PHPUnit_Framework_TestCase
         $router->add($route, 'var_dump');
 
         $router->handleArgs($args);
+    }
+
+    public function testHandleRouteWithCustomFilterModifier()
+    {
+        $tokenizer = new Tokenizer();
+        $tokenizer->addFilter('lower', function (&$value) {
+            $value = strtolower($value);
+            return true;
+        });
+
+        $called = null;
+        $router = new Router($tokenizer);
+        $router->add('add <name:lower>', function ($args) use (&$called) {
+            $called = $args;
+        });
+
+        $router->handleArgs(array('add', 'TeSt'));
+
+        $this->assertEquals(array('name' => 'test'), $called);
     }
 
     public function testAddRouteCanBeRemoved()

--- a/tests/Tokens/ArgumentTokenTest.php
+++ b/tests/Tokens/ArgumentTokenTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use Clue\Commander\Tokens\ArgumentToken;
+
+class ArgumentTokenTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCtorThrowsWithUnknownFilter()
+    {
+        new ArgumentToken('name', 'unknown');
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCtorThrowsWithInvalidCallable()
+    {
+        new ArgumentToken('name', 'filter', 'nope');
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCtorThrowsWithoutFilterButWithCallable()
+    {
+        new ArgumentToken('name', null, function () { });
+    }
+
+    public function testCtorDoesNotCallCallback()
+    {
+        $called = 0;
+        new ArgumentToken('name', 'int', function () use (&$called) {
+            ++$called;
+        });
+
+        $this->assertEquals(0, $called);
+    }
+
+    public function testMatchCallsCustomCallbackWithInputReturnsFalseDoesNotModifyInput()
+    {
+        $called = null;
+        $token = new ArgumentToken('name', 'int', function (&$value) use (&$called) {
+            $called = $value;
+            $value = strtoupper($value);
+            return false;
+        });
+
+        $input = array('hello');
+        $output = array();
+        $ret = $token->matches($input, $output);
+
+        $this->assertFalse($ret);
+        $this->assertEquals('hello', $called);
+        $this->assertEquals(array('hello'), $input);
+        $this->assertEquals(array(), $output);
+    }
+
+    public function testMatchCallsCustomCallbackWithInputReturnsTrueDoesModifyOutput()
+    {
+        $called = null;
+        $token = new ArgumentToken('name', 'int', function (&$value) use (&$called) {
+            $called = $value;
+            $value = strtoupper($value);
+            return true;
+        });
+
+        $input = array('hello');
+        $output = array();
+        $ret = $token->matches($input, $output);
+
+        $this->assertTrue($ret);
+        $this->assertEquals('hello', $called);
+        $this->assertEquals(array(), $input);
+        $this->assertEquals(array('name' => 'HELLO'), $output);
+    }
+}

--- a/tests/Tokens/TokenizerTest.php
+++ b/tests/Tokens/TokenizerTest.php
@@ -9,6 +9,9 @@ class TokenizerTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->tokenizer = new Tokenizer();
+        $this->tokenizer->addFilter('ip', function ($ip) {
+            return filter_var($ip, FILTER_VALIDATE_IP);
+        });
     }
 
     public function provideValidTokens()
@@ -32,6 +35,9 @@ class TokenizerTest extends PHPUnit_Framework_TestCase
             ),
             'word with argument filter' => array(
                 'hello <id:int>'
+            ),
+            'word with custom argument filter' => array(
+                'hello <target:ip>'
             ),
 
             'word with optional word' => array(


### PR DESCRIPTION
Add `Tokenizer::addFilter()` method to support adding custom filter callbacks:

```php
$tokenizer = new Tokenizer();
$tokenizer->addFilter('ip', function ($value) {
    return filter_var($ip, FILTER_VALIDATE_IP);
});
$tokenizer->addFilter('lower', function (&$value) {
    $value = strtolower($value);
    return true;
});

$router = new Router($tokenizer);
$router->add('add <name:lower>', function ($args) { });
$router->add('--search=<address:ip>', function ($args) { });
```