### PR TITLE
Run tests on  PHP 8, PHP 7.4 and PHPUnit 9 and update PHPUnit configuration schema for PHPUnit 9.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.gitattributes export-ignore
+/.github/workflows/ export-ignore
+/.gitignore export-ignore
+/examples/ export-ignore
+/phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
+/tests/ export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.0
           - 7.4
           - 7.3
           - 7.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
           php-version: ${{ matrix.php }}
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
+        if: ${{ matrix.php >= 7.3 }}
+      - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
+        if: ${{ matrix.php < 7.3 }}
 
   PHPUnit-hhvm:
     name: PHPUnit (HHVM)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
     strategy:
       matrix:
         php:
+          - 7.4
+          - 7.3
           - 7.2
           - 7.1
           - 7.0

--- a/README.md
+++ b/README.md
@@ -607,6 +607,11 @@ $ composer require clue/commander:^1.3
 
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
+This project aims to run on any platform and thus does not require any PHP
+extensions and supports running on legacy PHP 5.3 through current PHP 8+ and
+HHVM.
+It's *highly recommended to use PHP 7+* for this project.
+
 ## Tests
 
 To run the test suite, you first need to clone this repo and then install all

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,14 @@
     "autoload": {
         "psr-4": { "Clue\\Commander\\": "src/" }
     },
+    "autoload-dev": {
+        "psr-4": { "Clue\\Tests\\Commander\\": "tests/" }
+    },
     "require": {
         "php": ">=5.3"
     },
     "require-dev": {
         "clue/arguments": "^1.0",
-        "phpunit/phpunit": "^5.0 || ^4.8"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResult="false">
     <testsuites>
-        <testsuite>
+        <testsuite name="Commander test suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,16 @@
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Commander test suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -1,8 +1,10 @@
 <?php
 
+namespace Clue\Tests\Commander;
+
 use Clue\Commander\Route;
 
-class RouteTest extends PHPUnit_Framework_TestCase
+class RouteTest extends TestCase
 {
     public function testToStringWillReturnStringFromToken()
     {

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -1,9 +1,11 @@
 <?php
 
+namespace Clue\Tests\Commander;
+
 use Clue\Commander\Router;
 use Clue\Commander\Tokens\Tokenizer;
 
-class RouterTest extends PHPUnit_Framework_TestCase
+class RouterTest extends TestCase
 {
     public function testEmptyRouterHasNoRoutes()
     {
@@ -443,7 +445,6 @@ class RouterTest extends PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider provideNonMatchingRoutes
-     * @expectedException Clue\Commander\NoRouteFoundException
      * @param string $route
      * @param array  $args
      */
@@ -452,6 +453,7 @@ class RouterTest extends PHPUnit_Framework_TestCase
         $router = new Router();
         $router->add($route, 'var_dump');
 
+        $this->setExpectedException('Clue\Commander\NoRouteFoundException');
         $router->handleArgs($args);
     }
 
@@ -485,25 +487,22 @@ class RouterTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $router->getRoutes());
     }
 
-    /**
-     * @expectedException UnderflowException
-     */
     public function testCanNotRemoveRouteWhichHasNotBeenAdded()
     {
         $router = new Router();
         $route = $router->add('hello', function () { });
 
         $router2 = new Router();
+
+        $this->setExpectedException('UnderflowException');
         $router2->remove($route);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testAddRouteThrowsForInvalidHandler()
     {
         $router = new Router();
 
+        $this->setExpectedException('InvalidArgumentException');
         $router->add('hello', 'invalid');
     }
 
@@ -579,13 +578,11 @@ class RouterTest extends PHPUnit_Framework_TestCase
         $_SERVER = $old;
     }
 
-    /**
-     * @expectedException Clue\Commander\NoRouteFoundException
-     */
     public function testHandleEmptyRouterThrowsUnderflowException()
     {
         $router = new Router();
 
+        $this->setExpectedException('Clue\Commander\NoRouteFoundException');
         $router->handleArgs(array());
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Clue\Tests\Commander;
+
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
+{
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5.2+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 5.1
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
+    }
+}

--- a/tests/Tokens/AlternativeTokenTest.php
+++ b/tests/Tokens/AlternativeTokenTest.php
@@ -1,11 +1,17 @@
 <?php
 
+namespace Clue\Tests\Commander\Tokens;
+
 use Clue\Commander\Tokens\AlternativeToken;
 use Clue\Commander\Tokens\OptionalToken;
 use Clue\Commander\Tokens\WordToken;
+use Clue\Tests\Commander\TestCase;
 
-class AlternativeTokenTest extends PHPUnit_Framework_TestCase
+class AlternativeTokenTest extends TestCase
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testSupportsAnyTwoTokens()
     {
         new AlternativeToken(array(
@@ -14,19 +20,15 @@ class AlternativeTokenTest extends PHPUnit_Framework_TestCase
         ));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testRequiresTokens()
     {
+        $this->setExpectedException('InvalidArgumentException');
         new AlternativeToken(array());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testRequiresValidTokens()
     {
+        $this->setExpectedException('InvalidArgumentException');
         new AlternativeToken(array(
             true,
             false,

--- a/tests/Tokens/ArgumentTokenTest.php
+++ b/tests/Tokens/ArgumentTokenTest.php
@@ -1,30 +1,27 @@
 <?php
 
-use Clue\Commander\Tokens\ArgumentToken;
+namespace Clue\Tests\Commander\Tokens;
 
-class ArgumentTokenTest extends PHPUnit_Framework_TestCase
+use Clue\Commander\Tokens\ArgumentToken;
+use Clue\Tests\Commander\TestCase;
+
+class ArgumentTokenTest extends TestCase
 {
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testCtorThrowsWithUnknownFilter()
     {
+        $this->setExpectedException('InvalidArgumentException');
         new ArgumentToken('name', 'unknown');
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testCtorThrowsWithInvalidCallable()
     {
+        $this->setExpectedException('InvalidArgumentException');
         new ArgumentToken('name', 'filter', 'nope');
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testCtorThrowsWithoutFilterButWithCallable()
     {
+        $this->setExpectedException('InvalidArgumentException');
         new ArgumentToken('name', null, function () { });
     }
 

--- a/tests/Tokens/EllipseTokenTest.php
+++ b/tests/Tokens/EllipseTokenTest.php
@@ -1,10 +1,16 @@
 <?php
 
+namespace Clue\Tests\Commander\Tokens;
+
 use Clue\Commander\Tokens\EllipseToken;
 use Clue\Commander\Tokens\WordToken;
+use Clue\Tests\Commander\TestCase;
 
-class EllipseTokenTest extends PHPUnit_Framework_TestCase
+class EllipseTokenTest extends TestCase
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testSupportsWordToken()
     {
         new EllipseToken(new WordToken('test'));

--- a/tests/Tokens/OptionTokenTest.php
+++ b/tests/Tokens/OptionTokenTest.php
@@ -1,15 +1,16 @@
 <?php
 
+namespace Clue\Tests\Commander\Tokens;
+
 use Clue\Commander\Tokens\OptionToken;
 use Clue\Commander\Tokens\WordToken;
+use Clue\Tests\Commander\TestCase;
 
-class OptionTokenTest extends PHPUnit_Framework_TestCase
+class OptionTokenTest extends TestCase
 {
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testUnableToCreateOptionWithRequiredValueButNoPlaceholder()
     {
+        $this->setExpectedException('InvalidArgumentException');
         new OptionToken('--name', null, true);
     }
 }

--- a/tests/Tokens/SentenceTokenTest.php
+++ b/tests/Tokens/SentenceTokenTest.php
@@ -1,10 +1,16 @@
 <?php
 
+namespace Clue\Tests\Commander\Tokens;
+
 use Clue\Commander\Tokens\SentenceToken;
 use Clue\Commander\Tokens\WordToken;
+use Clue\Tests\Commander\TestCase;
 
-class SentenceTokenTest extends PHPUnit_Framework_TestCase
+class SentenceTokenTest extends TestCase
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testSupportsAnyTwoTokens()
     {
         new SentenceToken(array(
@@ -13,11 +19,9 @@ class SentenceTokenTest extends PHPUnit_Framework_TestCase
         ));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testRequiresValidTokens()
     {
+        $this->setExpectedException('InvalidArgumentException');
         new SentenceToken(array(
             true,
             false,

--- a/tests/Tokens/TokenizerTest.php
+++ b/tests/Tokens/TokenizerTest.php
@@ -1,12 +1,18 @@
 <?php
 
-use Clue\Commander\Tokens\Tokenizer;
+namespace Clue\Tests\Commander\Tokens;
 
-class TokenizerTest extends PHPUnit_Framework_TestCase
+use Clue\Commander\Tokens\Tokenizer;
+use Clue\Tests\Commander\TestCase;
+
+class TokenizerTest extends TestCase
 {
     private $tokenizer;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpTokenizer()
     {
         $this->tokenizer = new Tokenizer();
         $this->tokenizer->addFilter('ip', function ($ip) {
@@ -245,11 +251,11 @@ class TokenizerTest extends PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider provideInvalidTokens
-     * @expectedException InvalidArgumentException
      * @param string $expression
      */
     public function testInvalidTokens($expression)
     {
+        $this->setExpectedException('InvalidArgumentException');
         $this->tokenizer->createToken($expression);
     }
 


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.
For further details concerning this pull request look into https://github.com/graphp/graphviz/pull/46.

It's also possible to run this code with PHP 8 🎉
 ```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.0.0beta2-cli php vendor/bin/phpunit
PHPUnit 9.5.0 by Sebastian Bergmann and contributors.

...............................................................  63 / 193 ( 32%)
............................................................... 126 / 193 ( 65%)
............................................................... 189 / 193 ( 97%)
....                                                            193 / 193 (100%)

Time: 00:00.028, Memory: 6.00 MB

OK (193 tests, 255 assertions)
```